### PR TITLE
Hotfix license strategy link fix

### DIFF
--- a/docs/about/charter.md
+++ b/docs/about/charter.md
@@ -31,7 +31,7 @@ We believe that every member has a voice, and we encourage active participation 
 
 ## Licensing Strategy
 
-[TBA]
+See [LICENSE](license.md) for details.
 
 ## Identification of Key Trademarks
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Licensing Strategy in the About/Charter documentation, replacing a placeholder with a direct link to the LICENSE file to improve clarity and discoverability of licensing details.
  * No feature or API changes; user experience remains unchanged. Readers can now quickly access authoritative licensing terms without ambiguity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->