### PR TITLE
Fixed license link in charter

### DIFF
--- a/docs/about/charter.md
+++ b/docs/about/charter.md
@@ -31,7 +31,7 @@ We believe that every member has a voice, and we encourage active participation 
 
 ## Licensing Strategy
 
-[TBA]
+See [LICENSE](license.md) for details.
 
 ## Identification of Key Trademarks
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Charter page to replace a placeholder with a direct link to the license details (“See LICENSE for details”), improving clarity on licensing.
  * No changes to app behavior or features; this is a documentation-only update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->